### PR TITLE
49 hide dropdown menu after player selection

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -32,13 +32,11 @@ function setPlayer(event) {
 }
 
 // Function to hide dropdown menu
+
 function hideDropdown() {
-  const dropdownMenu = document.querySelector('.dropdown-menu.show');
-  if (dropdownMenu) {
-    const dropdown = bootstrap.Dropdown.getInstance(document.getElementById('player-selector'));
-    if (dropdown) {
-      dropdown.hide();
-    }
+  const dropdown = document.querySelector('.dropdown'); // Select the entire dropdown div
+  if (dropdown) {
+    dropdown.style.display = 'none'; // Hide the entire dropdown container
   }
 }
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -32,11 +32,10 @@ function setPlayer(event) {
 }
 
 // Function to hide dropdown menu
-
 function hideDropdown() {
-  const dropdown = document.querySelector('.dropdown'); // Select the entire dropdown div
+  const dropdown = document.querySelector('.dropdown');
   if (dropdown) {
-    dropdown.style.display = 'none'; // Hide the entire dropdown container
+    dropdown.style.display = 'none';
   }
 }
 


### PR DESCRIPTION
Previously, only the dropdown options disappeared after selection, leaving the button visible. Now, the entire dropdown button (including options) disappears once a player is selected

